### PR TITLE
mark as busy before forking horse

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -428,7 +428,9 @@ class Worker(object):
                     break
 
                 job, queue = result
+                self.set_state('busy')
                 self.execute_job(job)
+                self.set_state('idle')
                 self.heartbeat()
 
                 if job.get_status() == JobStatus.FINISHED:


### PR DESCRIPTION
Set the worker to busy before forking the horse. Right now only the fork is set to busy and SIGINT will kill the worker without waiting for the horse to finish.
